### PR TITLE
Pseudo-random piece generation

### DIFF
--- a/Assets/_Scenes/Level_TEST_EF.unity
+++ b/Assets/_Scenes/Level_TEST_EF.unity
@@ -628,7 +628,7 @@ GameObject:
   - component: {fileID: 365458654}
   - component: {fileID: 365458655}
   m_Layer: 0
-  m_Name: -----GameBoard-----
+  m_Name: GameBoard
   m_TagString: GameBoard
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -669,6 +669,7 @@ MonoBehaviour:
   gamePieceWidth: 0.5
   gamePieceHeight: 0.5
   gamePiece: {fileID: 8489439618648616055, guid: 366f201964094824fb96721261d907d5, type: 3}
+  potentialPieces: 01000000020000000300000004000000
 --- !u!1 &447275969
 GameObject:
   m_ObjectHideFlags: 0
@@ -843,7 +844,7 @@ GameObject:
   m_Component:
   - component: {fileID: 818164583}
   m_Layer: 0
-  m_Name: -----Environment-----
+  m_Name: Environment
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1391,7 +1392,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1274984820}
   m_Layer: 0
-  m_Name: -----UI-----
+  m_Name: UI
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2095,9 +2096,9 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1698784974}
+  - {fileID: 1274984820}
   - {fileID: 818164583}
   - {fileID: 365458654}
-  - {fileID: 1274984820}
   - {fileID: 275245693}
   - {fileID: 1381450605}
   - {fileID: 1781714266}

--- a/Assets/_Scripts/Data/F_GameSettings.cs
+++ b/Assets/_Scripts/Data/F_GameSettings.cs
@@ -4,4 +4,5 @@ public class F_GameSettings
 {
     public const int howManyInAMatch = 3;
     public const float playerHealthMax = 50.0f;
+    public const float playerISeconds = 3.0f;
 }

--- a/Assets/_Scripts/GameBoard.cs
+++ b/Assets/_Scripts/GameBoard.cs
@@ -20,6 +20,8 @@ public class GameBoard : MonoBehaviour
     [SerializeField] private float gamePieceWidth;
     [SerializeField] private float gamePieceHeight;
     [SerializeField] private GameObject gamePiece;
+    [SerializeField] private List<PieceTypes> potentialPieces = new();
+    private List<PieceTypes> generatedPieces = new();
 
     private Dictionary<Vector2, GameObject> gamePieces;
 
@@ -72,18 +74,6 @@ public class GameBoard : MonoBehaviour
     {
         GameObject tempGamePiece;
 
-        List<PieceTypes> generatedPieces = new();
-        List<PieceTypes> potentialPieces = new();
-        // potentialPieces = generatedPieces.Keys.ToList();
-        foreach (PieceTypes val in Enum.GetValues(typeof(PieceTypes)))
-        {
-            potentialPieces.Add(val);
-        }
-        potentialPieces.Remove(PieceTypes.None);
-        potentialPieces.Remove(PieceTypes.Powerup1);
-        potentialPieces.Remove(PieceTypes.Powerup2);
-        potentialPieces.Remove(PieceTypes.Powerup3);
-
         for (int row = 0; row < divisions; row++)
         {
             for (int col = 0; col < divisions; col++)
@@ -105,42 +95,7 @@ public class GameBoard : MonoBehaviour
                         tempPieceData.SetNewRotation(tempGamePiece.transform.rotation);
                         tempPieceData.SetNewScale(tempGamePiece.transform.localScale);
                         tempPieceData.SetGameBoard(this);
-                        AssignPieceTypes(tempPieceData);
-                    /*
-                    // Assign a pseudo-random piece type
-                        // Generate a piece using a new random value. 
-                        int rndIndex = UnityEngine.Random.Range(0, potentialPieces.Count);
-                        PieceTypes randomPieceType = potentialPieces[rndIndex];
-
-                        if (!generatedPieces.Contains(randomPieceType))
-                        {
-                            generatedPieces.Clear();
-                            generatedPieces.Add(randomPieceType);
-                            tempPieceData.SetPieceType(randomPieceType);
-
-                            // Debug.Log("Piece: " + tempPieceData.GetInstanceID() + " | Type: " + randomPieceType.ToString());
-                        } 
-                        else if (generatedPieces.LastIndexOf(randomPieceType) < 1)
-                        {
-                            generatedPieces.Add(randomPieceType);
-                            tempPieceData.SetPieceType(randomPieceType);
-                            
-                            // Debug.Log("Piece: " + tempPieceData.GetInstanceID() + " | Type: " + randomPieceType.ToString());
-                        } else
-                        {
-                            // Remove piece that would generate a match
-                            potentialPieces.Remove(randomPieceType);
-                            rndIndex = UnityEngine.Random.Range(0, potentialPieces.Count);
-                            PieceTypes newRandomPiece = potentialPieces[rndIndex];
-                            generatedPieces.Clear();
-                            generatedPieces.Add(newRandomPiece);
-                            tempPieceData.SetPieceType(newRandomPiece);
-                            // Re-add the piece that would have generated a match
-                            potentialPieces.Add(randomPieceType);
-
-                            // Debug.Log("Piece: " + tempPieceData.GetInstanceID() + " | Type: " + newRandomPiece.ToString());
-                        }
-                    */    
+                        AssignPieceType(tempPieceData); 
                 } else 
                 { 
                     Debug.LogError("Fatal: Piece data not found on game object."); 
@@ -162,52 +117,77 @@ public class GameBoard : MonoBehaviour
     {
         foreach (var piece in gamePieces.Values)
         {
-            AssignPieceTypes(piece.GetComponent<GamePiece>());
+            AssignPieceType(piece.GetComponent<GamePiece>());
         }
     }
 
-    private void AssignPieceTypes(GamePiece pieceData)
+    private void AssignPieceType(GamePiece pieceData)
     {
-        List<PieceTypes> generatedPieces = new();
-        List<PieceTypes> potentialPieces = new();
-        // potentialPieces = generatedPieces.Keys.ToList();
-        foreach (PieceTypes val in Enum.GetValues(typeof(PieceTypes)))
+        if (potentialPieces.Count < 1)
         {
-            potentialPieces.Add(val);
+            potentialPieces.Add(PieceTypes.Red);
+            Debug.Log("Piece types not set for the level. Remember to set up the game state completely!");
         }
-        potentialPieces.Remove(PieceTypes.None);
-        potentialPieces.Remove(PieceTypes.Powerup1);
-        potentialPieces.Remove(PieceTypes.Powerup2);
-        potentialPieces.Remove(PieceTypes.Powerup3);
 
         // Assign a pseudo-random piece type
         // Generate a piece using a new random value. 
         int rndIndex = UnityEngine.Random.Range(0, potentialPieces.Count);
         PieceTypes randomPieceType = potentialPieces[rndIndex];
 
-        if (!generatedPieces.Contains(randomPieceType))
+        /*
+        /// The below functionality checks to ensure pieces are random
+        /// based on the historic placement of them. It has been dummied
+        /// out because it does not check vertical matches. However,
+        /// it is likely much more performant than the implemented solution.
+        /// As such, it has been left in case it proves necessary to refactor
+        /// to accomdate the performance requirements of the target devices. 
+                if (!generatedPieces.Contains(randomPieceType))
+                {
+                    generatedPieces.Clear();
+                    generatedPieces.Add(randomPieceType);
+                    pieceData.SetPieceType(randomPieceType);
+                }
+                else if (generatedPieces.LastIndexOf(randomPieceType) < 1)
+                {
+                    generatedPieces.Add(randomPieceType);
+                    pieceData.SetPieceType(randomPieceType);
+                }
+                else
+                {
+                    PieceTypes newRandomPiece = ScrambleMatchedPiece(randomPieceType);
+                    generatedPieces.Add(ScrambleMatchedPiece(newRandomPiece));
+                    pieceData.SetPieceType(newRandomPiece);
+                }
+        */
+
+        pieceData.SetPieceType(randomPieceType);
+
+        if (pieceData.FindHorizontalMatches().Count > 1)
         {
-            generatedPieces.Clear();
-            generatedPieces.Add(randomPieceType);
-            pieceData.SetPieceType(randomPieceType);
-        }
-        else if (generatedPieces.LastIndexOf(randomPieceType) < 1)
-        {
-            generatedPieces.Add(randomPieceType);
-            pieceData.SetPieceType(randomPieceType);
-        }
-        else
-        {
-            // Remove piece that would generate a match
-            potentialPieces.Remove(randomPieceType);
-            rndIndex = UnityEngine.Random.Range(0, potentialPieces.Count);
-            PieceTypes newRandomPiece = potentialPieces[rndIndex];
-            generatedPieces.Clear();
-            generatedPieces.Add(newRandomPiece);
+            PieceTypes newRandomPiece = ScrambleMatchedPiece(pieceData.GetPieceType());
             pieceData.SetPieceType(newRandomPiece);
-            // Re-add the piece that would have generated a match
-            potentialPieces.Add(randomPieceType);
         }
+
+        if (pieceData.FindVerticalMatches().Count > 1)
+        {
+            PieceTypes newRandomPiece = ScrambleMatchedPiece(pieceData.GetPieceType());
+            pieceData.SetPieceType(newRandomPiece);
+        }
+    }
+
+    private PieceTypes ScrambleMatchedPiece(PieceTypes match)
+    {
+
+        // Remove piece that would generate a match
+        potentialPieces.Remove(match);
+        int rndIndex = UnityEngine.Random.Range(0, potentialPieces.Count);
+        PieceTypes newRandomPiece = potentialPieces[rndIndex];
+        generatedPieces.Clear();
+        generatedPieces.Add(newRandomPiece);
+        // Re-add the piece that would have generated a match
+        potentialPieces.Add(match);
+
+        return newRandomPiece;
     }
 
     private IEnumerator PopulateMatches()

--- a/Assets/_Scripts/GamePiece.cs
+++ b/Assets/_Scripts/GamePiece.cs
@@ -155,10 +155,12 @@ public class GamePiece : MonoBehaviour
     }
 
     /// <summary>
-    /// BUGGED
+    /// Recursively searches horizontally to find matches.
+    /// Will branch vertically if matches are found. 
+    /// Returns the grid positions of the matches found. 
     /// </summary>
     /// <returns></returns>
-    public int FindHorizontalMatches(GamePiece searchChainOrigin = null)
+    public List<Vector2> FindHorizontalMatches(GamePiece searchChainOrigin = null)
     {
         GamePiece tempData;
         Vector2 gridLocation = gameBoard.WorldPositionToGrid(originalPosition);
@@ -206,10 +208,17 @@ public class GamePiece : MonoBehaviour
         }
 
         // Debug.Log("Piece data " + this.GetInstanceID() + " has " + horizontalMatches.Count + " horizontal matches.");
-        return horizontalMatches.Count;
+        return horizontalMatches;
     }
 
-    public int FindVerticalMatches(GamePiece searchChainOrigin = null)
+    /// <summary>
+    /// Recursively searches vertically to find matches.
+    /// Will branch horizontally if matches are found. 
+    /// Returns the grid positions of the matches found. 
+    /// </summary>
+    /// <param name="searchChainOrigin"></param>
+    /// <returns></returns>
+    public List<Vector2> FindVerticalMatches(GamePiece searchChainOrigin = null)
     {
         GamePiece tempData;
         Vector2 gridLocation = gameBoard.WorldPositionToGrid(originalPosition);
@@ -258,7 +267,7 @@ public class GamePiece : MonoBehaviour
         }
 
         // Debug.Log("Piece data " + this.GetInstanceID() + " has " + verticalMatches.Count + " vertical matches.");
-        return verticalMatches.Count;
+        return verticalMatches;
     }
 
     public IEnumerator MatchMade()

--- a/Assets/_Scripts/PlayerController.cs
+++ b/Assets/_Scripts/PlayerController.cs
@@ -164,12 +164,12 @@ public class PlayerController : MonoBehaviour
             board.SwapPieces(heldPieceData.GetOriginalPosition(), swappedPiece.GetOriginalPosition());
             // Debug.Log("Pieces swapped.");
 
-            heldHorizontalMatches = heldPieceData.FindHorizontalMatches();
-            heldVerticalMatches = heldPieceData.FindVerticalMatches();
+            heldHorizontalMatches = heldPieceData.FindHorizontalMatches().Count;
+            heldVerticalMatches = heldPieceData.FindVerticalMatches().Count;
             StartCoroutine(heldPieceData.MatchMade()); // Checks number of matches internally
 
-            touchedHorizontalMatches = swappedPiece.FindHorizontalMatches();
-            touchedVerticalMatches = swappedPiece.FindVerticalMatches();
+            touchedHorizontalMatches = swappedPiece.FindHorizontalMatches().Count;
+            touchedVerticalMatches = swappedPiece.FindVerticalMatches().Count;
             StartCoroutine(swappedPiece.MatchMade()); // Checks number of matches internally
 
 


### PR DESCRIPTION
The game board now properly generates pieces such that no matches exist initially.

Currently the 'find matches' methods for each game piece is called to ensure no matches have been made while generating.

Legacy code that handled this was more performant due to analyzing previously generated pieces. It has been commented out and left in place in the case that we need to return to this higher performance approach.