### PR TITLE
Bugfix/ef/enemy deals double hits

### DIFF
--- a/Assets/_Prefabs/Critical Systems/BattleUI.prefab
+++ b/Assets/_Prefabs/Critical Systems/BattleUI.prefab
@@ -1306,8 +1306,8 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8cb19e4736e89de45aa51d6f527b3473, type: 3}
---- !u!4 &4521575683833328441 stripped
-Transform:
+--- !u!224 &4521575683833328441 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 914962393105699941, guid: 8cb19e4736e89de45aa51d6f527b3473, type: 3}
   m_PrefabInstance: {fileID: 3606613996310226780}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/_Prefabs/Critical Systems/BattleUI.prefab
+++ b/Assets/_Prefabs/Critical Systems/BattleUI.prefab
@@ -1306,8 +1306,8 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8cb19e4736e89de45aa51d6f527b3473, type: 3}
---- !u!224 &4521575683833328441 stripped
-RectTransform:
+--- !u!4 &4521575683833328441 stripped
+Transform:
   m_CorrespondingSourceObject: {fileID: 914962393105699941, guid: 8cb19e4736e89de45aa51d6f527b3473, type: 3}
   m_PrefabInstance: {fileID: 3606613996310226780}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/_Scripts/PlayerController.cs
+++ b/Assets/_Scripts/PlayerController.cs
@@ -29,6 +29,8 @@ public class PlayerController : MonoBehaviour
     private EnemyHandler enemyHandler;
     // Player
     private float playerHealth = Settings.playerHealthMax;
+    private bool bIsInvincible = false;
+    private Coroutine CR_InvincibleTimer = null;
     
     private void Awake()
     {
@@ -216,13 +218,32 @@ public class PlayerController : MonoBehaviour
 
     public void TakeDamage(float damage)
     {
-        Debug.Log("Player damaged: " + damage);
-        playerHealth = Mathf.Clamp(playerHealth - damage, 0.0f, Settings.playerHealthMax);
-        UpdateHealthDisplay();
-        if (playerHealth <= 0.0f)
+        if (bIsInvincible)
         {
-            Debug.Log("Game over.");
-            SceneManager.LoadScene(sceneName: "GameOver");
+            Debug.Log("Player is invincible.");
+            return;
+        } else
+        {
+            Debug.Log("Player damaged: " + damage);
+            playerHealth = Mathf.Clamp(playerHealth - damage, 0.0f, Settings.playerHealthMax);
+            UpdateHealthDisplay();
+            if (playerHealth <= 0.0f)
+            {
+                Debug.Log("Game over.");
+                SceneManager.LoadScene(sceneName: "GameOver");
+            } else
+            {
+                if (CR_InvincibleTimer != null)
+                {
+                    StopCoroutine(CR_InvincibleTimer);
+                    CR_InvincibleTimer = StartCoroutine(InvincibleTimer(Settings.playerISeconds));
+                    bIsInvincible = true;
+                } else
+                {
+                    bIsInvincible = true;
+                    CR_InvincibleTimer = StartCoroutine(InvincibleTimer(Settings.playerISeconds));
+                }
+            }
         }
     }
 
@@ -274,6 +295,12 @@ public class PlayerController : MonoBehaviour
             Debug.Log("Board script invalid.");
             return null;
         }
+    }
+
+    private IEnumerator InvincibleTimer(float seconds)
+    {
+        yield return new WaitForSeconds(seconds);
+        bIsInvincible = false;
     }
 
 


### PR DESCRIPTION
## Bugfixes:
- Damage timer now correctly resets to full when advancing to a new wave.
- The enemy-damage-player logic no longer runs twice when advancing to a new wave.

A redundant system has been added that will ensure the player does not receive double hits even should the coroutines become out of sync. This is still an area that could use improvement.