### PR TITLE
Resolution Fix

### DIFF
--- a/Assets/_Prefabs/Critical Systems/BattleUI.prefab
+++ b/Assets/_Prefabs/Critical Systems/BattleUI.prefab
@@ -264,7 +264,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -35, y: 100}
+  m_AnchoredPosition: {x: -35, y: 80}
   m_SizeDelta: {x: 60, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4048243599128355339
@@ -381,11 +381,11 @@ RectTransform:
   - {fileID: 7154161472942881174}
   m_Father: {fileID: 8292766806675819802}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 310}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -20}
   m_SizeDelta: {x: 340, y: 10}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!1 &4538507319121766986
 GameObject:
   m_ObjectHideFlags: 0
@@ -604,7 +604,7 @@ MonoBehaviour:
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 300
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 360, y: 640}
+  m_ReferenceResolution: {x: 393, y: 873}
   m_ScreenMatchMode: 1
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
@@ -663,7 +663,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 10, y: -20}
+  m_AnchoredPosition: {x: 10, y: -40}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &1569877829196735104
@@ -1057,7 +1057,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 65}
+  m_AnchoredPosition: {x: 0, y: 40}
   m_SizeDelta: {x: 340, y: 10}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7569018748968734563
@@ -1301,13 +1301,17 @@ PrefabInstance:
       propertyPath: m_Name
       value: PauseSystem
       objectReference: {fileID: 0}
+    - target: {fileID: 3951200542721116790, guid: 8cb19e4736e89de45aa51d6f527b3473, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -40
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8cb19e4736e89de45aa51d6f527b3473, type: 3}
---- !u!4 &4521575683833328441 stripped
-Transform:
+--- !u!224 &4521575683833328441 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 914962393105699941, guid: 8cb19e4736e89de45aa51d6f527b3473, type: 3}
   m_PrefabInstance: {fileID: 3606613996310226780}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/_Scenes/Level_00.unity
+++ b/Assets/_Scenes/Level_00.unity
@@ -131,13 +131,49 @@ PrefabInstance:
       propertyPath: m_Name
       value: GameBoard
       objectReference: {fileID: 0}
+    - target: {fileID: 1264152052117249145, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
+      propertyPath: width
+      value: 1.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1264152052117249145, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
+      propertyPath: height
+      value: 1.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1264152052117249145, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
+      propertyPath: divisions
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1264152052117249145, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
+      propertyPath: cellSize.x
+      value: 0.5889016
+      objectReference: {fileID: 0}
+    - target: {fileID: 1264152052117249145, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
+      propertyPath: cellSize.y
+      value: 0.5889016
+      objectReference: {fileID: 0}
+    - target: {fileID: 1264152052117249145, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
+      propertyPath: gamePieceWidth
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1264152052117249145, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
+      propertyPath: gamePieceHeight
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1264152052117249145, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
+      propertyPath: boardStartPosition.x
+      value: -2.3556063
+      objectReference: {fileID: 0}
+    - target: {fileID: 1264152052117249145, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
+      propertyPath: boardStartPosition.y
+      value: -2.6556063
+      objectReference: {fileID: 0}
     - target: {fileID: 7517736218054245218, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7517736218054245218, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.3
       objectReference: {fileID: 0}
     - target: {fileID: 7517736218054245218, guid: eb6b4f87ee388d04aa1ae825b518419f, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/_Scripts/GameBoard.cs
+++ b/Assets/_Scripts/GameBoard.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Rendering.Universal;
+using UnityEngine.Video;
 using PieceTypes = E_PieceTypes.PieceType;
 
 public class GameBoard : MonoBehaviour
@@ -12,12 +14,16 @@ public class GameBoard : MonoBehaviour
     
     // Private
     [Header("Board Settings")]
-    [SerializeField] private int width;
-    [SerializeField] private int height;
+    [Range(0.1f, 1.5f)]
+    [SerializeField] private float width;
+    [Range(0.1f, 1.5f)]
+    [SerializeField] private float height;
     [Range(2, 30)]
     [SerializeField] private int divisions;
     [Header("Game Piece Settings")]
+    [Range(0.1f, 1.0f)]
     [SerializeField] private float gamePieceWidth;
+    [Range(0.1f, 1.0f)]
     [SerializeField] private float gamePieceHeight;
     [SerializeField] private GameObject gamePiece;
     [SerializeField] private List<PieceTypes> potentialPieces = new();
@@ -37,9 +43,12 @@ public class GameBoard : MonoBehaviour
     private void OnDrawGizmos()
     {
         if (Application.isPlaying) return;
-        
+
+        // Debug.Log("Screen to world point width,height: " + Camera.main.ScreenToWorldPoint(new Vector3(width, height, 10.0f)));
+
         Gizmos.color = Color.cyan;
-        Gizmos.DrawWireCube(transform.position, new Vector3(width, height, 0.0f));
+        Gizmos.DrawWireCube(transform.position, new Vector3(Camera.main.orthographicSize * 2 * Camera.main.aspect * width,
+                                                            Camera.main.orthographicSize * 2 * Camera.main.aspect * height, 0.0f));
         for (int row = 0; row < divisions; row++)
         {
             for (int col = 0; col < divisions; col++)
@@ -50,7 +59,7 @@ public class GameBoard : MonoBehaviour
                     boardStartPosition.x + (col * cellSize.x) + (cellSize.x / 2), 
                     boardStartPosition.y + (row * cellSize.y) + (cellSize.y / 2),
                     transform.position.z), 
-                    new Vector3(gamePieceWidth, gamePieceHeight, 0.0f));
+                    new Vector3(gamePieceWidth*cellSize.x, gamePieceHeight*cellSize.y, 0.0f));
             }
         }
     }
@@ -83,7 +92,7 @@ public class GameBoard : MonoBehaviour
                                             boardStartPosition.y + (row * cellSize.y) + (cellSize.y / 2),
                                             transform.position.z),
                                             Quaternion.identity);
-                tempGamePiece.transform.localScale = new Vector3(gamePieceWidth, gamePieceHeight, (gamePieceWidth+gamePieceHeight)/2);
+                tempGamePiece.transform.localScale = new Vector3(gamePieceWidth*cellSize.x, gamePieceHeight*cellSize.y, (gamePieceWidth+gamePieceHeight)/2);
                 tempGamePiece.transform.parent = transform;
                 
                 if (tempGamePiece.GetComponent<GamePiece>() != null)
@@ -205,11 +214,11 @@ public class GameBoard : MonoBehaviour
 
     private Vector2 BoardStartPosition()
     {
-        return new Vector2(transform.position.x - (float)width / 2, transform.position.y - (float)height / 2);
+        return new Vector2((transform.position.x - Camera.main.orthographicSize * 2 * Camera.main.aspect * (float)width / 2), (transform.position.y - Camera.main.orthographicSize * 2 * Camera.main.aspect * (float)height / 2));
     }
     private Vector2 CellSize()
     {
-        return new Vector2((float)width / divisions, (float)height / divisions);
+        return new Vector2(Camera.main.orthographicSize * 2 * Camera.main.aspect * (float)width / divisions, Camera.main.orthographicSize * 2 * Camera.main.aspect * (float)height / divisions);
     }
 
     // Conversions


### PR DESCRIPTION
## Aspect Ratio
- The game board is now responsive to different device aspect ratios.
- Game pieces appropriately generate in the defined region.
- The game board and game piece width and height settings are now percentage based.
  - The game board width & height are rough percentages of the width & height of the screen. Note that this relies on the orthographic data of the screen which, due to our use of a perspective camera, is slightly different from the actual width & height.
  - The game piece width and height now describe a percentages of the total cell size. Pieces will now never be larger than the cell size which means that pieces, no matter the board settings, will never overlap with one another.